### PR TITLE
feat: gerenciar tratamento de excecoes e validacao campo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,8 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.0</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<version>3.3.4</version>
+		<relativePath/>
 	</parent>
 	<groupId>com.eventostec</groupId>
 	<artifactId>api</artifactId>
@@ -25,7 +25,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>
@@ -61,6 +64,18 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>software.amazon.awssdk</groupId>
 			<artifactId>s3</artifactId>
 			<version>2.26.7</version>
@@ -71,6 +86,15 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.13.0</version>
+				<configuration>
+					<source>21</source>
+					<target>21</target>
+				</configuration>
+			</plugin>
+			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 				<configuration>
@@ -80,6 +104,28 @@
 							<artifactId>lombok</artifactId>
 						</exclude>
 					</excludes>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.11</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<outputDirectory>${project.build.directory}/site/jacoco</outputDirectory>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/src/main/java/com/eventostec/api/controller/CouponController.java
+++ b/src/main/java/com/eventostec/api/controller/CouponController.java
@@ -3,7 +3,7 @@ package com.eventostec.api.controller;
 import com.eventostec.api.domain.coupon.Coupon;
 import com.eventostec.api.domain.coupon.CouponRequestDTO;
 import com.eventostec.api.service.CouponService;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -11,10 +11,10 @@ import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/coupon")
+@RequiredArgsConstructor
 public class CouponController {
 
-    @Autowired
-    private CouponService couponService;
+    private final CouponService couponService;
 
     @PostMapping("/event/{eventId}")
     public ResponseEntity<Coupon> addCouponsToEvent(@PathVariable UUID eventId, @RequestBody CouponRequestDTO data) {

--- a/src/main/java/com/eventostec/api/controller/EventController.java
+++ b/src/main/java/com/eventostec/api/controller/EventController.java
@@ -5,34 +5,25 @@ import com.eventostec.api.domain.event.EventDetailsDTO;
 import com.eventostec.api.domain.event.EventRequestDTO;
 import com.eventostec.api.domain.event.EventResponseDTO;
 import com.eventostec.api.service.EventService;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Page;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/event")
 public class EventController {
 
-    @Autowired
-    private EventService eventService;
+    private final EventService eventService;
 
     @PostMapping(consumes = "multipart/form-data")
-    public ResponseEntity<Event> create(@RequestParam("title") String title,
-                                        @RequestParam(value = "description", required = false) String description,
-                                        @RequestParam("date") Long date,
-                                        @RequestParam("city") String city,
-                                        @RequestParam("state") String state,
-                                        @RequestParam("remote") Boolean remote,
-                                        @RequestParam("eventUrl") String eventUrl,
-                                        @RequestParam(value = "image", required = false) MultipartFile image) {
-        EventRequestDTO eventRequestDTO = new EventRequestDTO(title, description, date, city, state, remote, eventUrl, image);
+    public ResponseEntity<Event> create(@Valid @ModelAttribute EventRequestDTO eventRequestDTO) {
         Event newEvent = this.eventService.createEvent(eventRequestDTO);
         return ResponseEntity.ok(newEvent);
     }

--- a/src/main/java/com/eventostec/api/domain/event/Event.java
+++ b/src/main/java/com/eventostec/api/domain/event/Event.java
@@ -1,7 +1,9 @@
 package com.eventostec.api.domain.event;
 
-import com.eventostec.api.domain.address.Address;
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/eventostec/api/domain/event/EventRequestDTO.java
+++ b/src/main/java/com/eventostec/api/domain/event/EventRequestDTO.java
@@ -1,8 +1,17 @@
 package com.eventostec.api.domain.event;
 
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.Date;
-
-public record EventRequestDTO(String title, String description, Long date, String city, String state, Boolean remote, String eventUrl, MultipartFile image) {
+public record EventRequestDTO(
+        @NotNull(message = "O título deve ser informado") String title,
+        @NotNull(message = "A descrição deve ser informada") String description,
+        @NotNull(message = "A data deve ser informada") Long date, String city,
+        @NotNull(message = "O estado deve ser informado") String state,
+        Boolean remote,
+        @Pattern(regexp = "^(https?://)(www\\.)?[a-zA-Z0-9-]+(\\.[a-zA-Z]{2,63}){1,3}(/[a-zA-Z0-9._~:/?#\\[\\]@!$&'()*+,;=-]*)?$", message = "URL inválida")
+        @NotEmpty(message = "O link para o evento deve ser informado") String eventUrl,
+        MultipartFile image) {
 }

--- a/src/main/java/com/eventostec/api/domain/event/EventResponseDTO.java
+++ b/src/main/java/com/eventostec/api/domain/event/EventResponseDTO.java
@@ -1,7 +1,5 @@
 package com.eventostec.api.domain.event;
 
-import org.springframework.web.multipart.MultipartFile;
-
 import java.util.Date;
 import java.util.UUID;
 

--- a/src/main/java/com/eventostec/api/exceptions/config/ApiExceptionHandler.java
+++ b/src/main/java/com/eventostec/api/exceptions/config/ApiExceptionHandler.java
@@ -1,0 +1,29 @@
+package com.eventostec.api.exceptions.config;
+
+import com.eventostec.api.utils.ExceptionUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.convert.ConversionFailedException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@ControllerAdvice
+public class ApiExceptionHandler {
+
+    @ExceptionHandler({
+            MethodArgumentTypeMismatchException.class,
+            MissingServletRequestParameterException.class,
+            DataIntegrityViolationException.class,
+            MethodArgumentNotValidException.class,
+            ConversionFailedException.class
+    })
+    public ResponseEntity<ProblemDetails> handleException(Exception ex, HttpServletRequest request) {
+        ProblemDetails problemDetails = ExceptionUtil.getProblemDetails(request, ex);
+        return new ResponseEntity<>(problemDetails, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/eventostec/api/exceptions/config/ProblemDetails.java
+++ b/src/main/java/com/eventostec/api/exceptions/config/ProblemDetails.java
@@ -1,0 +1,21 @@
+package com.eventostec.api.exceptions.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Based on RFC7807(<a href="https://datatracker.ietf.org/doc/html/rfc7807">Problem Details for HTTP APIs</a>)
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProblemDetails {
+    private String title;
+    private Integer code;
+    private String status;
+    private String detail;
+    private String instance;
+}

--- a/src/main/java/com/eventostec/api/service/AddressService.java
+++ b/src/main/java/com/eventostec/api/service/AddressService.java
@@ -4,17 +4,17 @@ import com.eventostec.api.domain.address.Address;
 import com.eventostec.api.domain.event.Event;
 import com.eventostec.api.domain.event.EventRequestDTO;
 import com.eventostec.api.repositories.AddressRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
 import java.util.UUID;
 
 @Service
+@RequiredArgsConstructor
 public class AddressService {
 
-    @Autowired
-    private AddressRepository addressRepository;
+    private final AddressRepository addressRepository;
 
     public Address createAddress(EventRequestDTO data, Event event) {
         Address address = new Address();

--- a/src/main/java/com/eventostec/api/service/CouponService.java
+++ b/src/main/java/com/eventostec/api/service/CouponService.java
@@ -1,11 +1,11 @@
 package com.eventostec.api.service;
 
 import com.eventostec.api.domain.coupon.Coupon;
-import com.eventostec.api.domain.event.Event;
 import com.eventostec.api.domain.coupon.CouponRequestDTO;
+import com.eventostec.api.domain.event.Event;
 import com.eventostec.api.repositories.CouponRepository;
 import com.eventostec.api.repositories.EventRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.Date;
@@ -13,13 +13,11 @@ import java.util.List;
 import java.util.UUID;
 
 @Service
+@RequiredArgsConstructor
 public class CouponService {
 
-    @Autowired
-    private CouponRepository couponRepository;
-
-    @Autowired
-    private EventRepository eventRepository;
+    private final CouponRepository couponRepository;
+    private final EventRepository eventRepository;
 
     public Coupon addCouponToEvent(UUID eventId, CouponRequestDTO couponData) {
         Event event = eventRepository.findById(eventId)

--- a/src/main/java/com/eventostec/api/utils/ExceptionUtil.java
+++ b/src/main/java/com/eventostec/api/utils/ExceptionUtil.java
@@ -1,0 +1,110 @@
+package com.eventostec.api.utils;
+
+import com.eventostec.api.exceptions.config.ProblemDetails;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.convert.ConversionFailedException;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.util.Optional;
+
+public final class ExceptionUtil {
+
+    public static final String TIPO_DESCONHECIDO = "tipo desconhecido";
+    public static final String VALOR_NAO_INFORMADO = "valor não informado";
+
+    private ExceptionUtil() {
+        throw new IllegalStateException("Cannot be instantiated");
+    }
+
+    public static ProblemDetails getProblemDetails(HttpServletRequest request, Exception ex) {
+        return switch (ex.getClass().getSimpleName()) {
+            case "MethodArgumentTypeMismatchException" -> handleMethodArgumentTypeMismatch((MethodArgumentTypeMismatchException) ex, request);
+            case "MissingServletRequestParameterException" ->
+                    handleMissingServletRequestParameter((MissingServletRequestParameterException) ex, request);
+            case "DataIntegrityViolationException" -> handleDataIntegrityViolation(request);
+            case "MethodArgumentNotValidException" -> handleMethodArgumentNotValid((MethodArgumentNotValidException) ex, request);
+            case "ConversionFailedException" -> handleConversionFailed((ConversionFailedException) ex, request);
+            default -> new ProblemDetails(
+                    "Erro não especificado",
+                    HttpStatus.BAD_REQUEST.value(),
+                    HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                    "Ocorreu um erro inesperado.",
+                    request.getRequestURI()
+            );
+        };
+    }
+
+    private static ProblemDetails handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException ex, HttpServletRequest request) {
+        String title = "Campo inválido informado";
+        String fieldName = ex.getName();
+        String requiredType = Optional.ofNullable(ex.getRequiredType())
+                .map(Class::getSimpleName)
+                .orElse(TIPO_DESCONHECIDO);
+        String invalidValue = Optional.ofNullable(ex.getValue())
+                .map(Object::toString)
+                .orElse(VALOR_NAO_INFORMADO);
+        String detail = String.format("O campo '%s' recebeu um valor inválido: '%s'. Esperava-se um valor do tipo '%s'.", fieldName, invalidValue, requiredType);
+
+        return new ProblemDetails(title, HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), detail, request.getRequestURI());
+    }
+
+    private static ProblemDetails handleMissingServletRequestParameter(MissingServletRequestParameterException ex, HttpServletRequest request) {
+        String title = "Campo não informado";
+        String detail = String.format("O dado do campo '%s' não foi informado.", ex.getParameterName());
+
+        return new ProblemDetails(title, HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), detail, request.getRequestURI());
+    }
+
+    private static ProblemDetails handleDataIntegrityViolation(HttpServletRequest request) {
+        String title = "Violação de integridade de campo";
+        String detail = "Violação de integridade detectada no banco de dados.";
+
+        return new ProblemDetails(title, HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), detail, request.getRequestURI());
+    }
+
+    private static ProblemDetails handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpServletRequest request) {
+        String title = "Validação de campo violada";
+        String failedValidationMessage = "A validação falhou em um campo não identificado.";
+        String detail;
+
+        if (ex.getBindingResult().hasFieldErrors()) {
+            FieldError fieldError = ex.getBindingResult().getFieldError();
+            if (fieldError != null) {
+                String violatedField = fieldError.getField();
+                String errorMessage = fieldError.getDefaultMessage();
+
+                if (errorMessage != null && errorMessage.contains("Failed to convert value of type")) {
+                    String rejectedValue = Optional.ofNullable(fieldError.getRejectedValue())
+                            .map(Object::toString)
+                            .orElse(VALOR_NAO_INFORMADO);
+                    errorMessage = String.format("'%s' não é válido.", rejectedValue);
+                }
+
+                detail = String.format("A validação do campo '%s' falhou: %s.", violatedField, errorMessage);
+            } else {
+                detail = failedValidationMessage;
+            }
+        } else {
+            detail = failedValidationMessage;
+        }
+
+        return new ProblemDetails(title, HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), detail, request.getRequestURI());
+    }
+
+    private static ProblemDetails handleConversionFailed(ConversionFailedException ex, HttpServletRequest request) {
+        String title = "Campo inválido informado";
+        String invalidValue = Optional.ofNullable(ex.getValue())
+                .map(Object::toString)
+                .orElse(VALOR_NAO_INFORMADO);
+        String requiredType = Optional.of(ex.getTargetType())
+                .map(typeDescriptor -> typeDescriptor.getType().getSimpleName())
+                .orElse(TIPO_DESCONHECIDO);
+        String detail = String.format("O valor '%s' fornecido é inválido. Esperava-se um valor do tipo '%s'.", invalidValue, requiredType);
+
+        return new ProblemDetails(title, HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), detail, request.getRequestURI());
+    }
+}

--- a/src/test/java/com/eventostec/api/ApiApplicationTests.java
+++ b/src/test/java/com/eventostec/api/ApiApplicationTests.java
@@ -10,6 +10,7 @@ class ApiApplicationTests {
 
 	@Test
 	void contextLoads() {
+		//Test the context application
 	}
 
 }

--- a/src/test/java/com/eventostec/api/controller/CouponControllerTest.java
+++ b/src/test/java/com/eventostec/api/controller/CouponControllerTest.java
@@ -1,0 +1,46 @@
+package com.eventostec.api.controller;
+
+import com.eventostec.api.domain.coupon.Coupon;
+import com.eventostec.api.domain.coupon.CouponRequestDTO;
+import com.eventostec.api.service.CouponService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Date;
+import java.util.UUID;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CouponController.class)
+class CouponControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CouponService couponService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void test_shouldReturnOk() throws Exception {
+        UUID eventId = UUID.randomUUID();
+        CouponRequestDTO requestDTO = new CouponRequestDTO("CODE123", 10, new Date().getTime());
+        Coupon responseCoupon = new Coupon();
+
+        when(couponService.addCouponToEvent(eventId, requestDTO)).thenReturn(responseCoupon);
+
+        mockMvc.perform(post("/api/coupon/event/{eventId}", eventId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDTO)))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/eventostec/api/controller/EventControllerTest.java
+++ b/src/test/java/com/eventostec/api/controller/EventControllerTest.java
@@ -1,0 +1,157 @@
+package com.eventostec.api.controller;
+
+import com.eventostec.api.domain.event.Event;
+import com.eventostec.api.domain.event.EventDetailsDTO;
+import com.eventostec.api.domain.event.EventRequestDTO;
+import com.eventostec.api.domain.event.EventResponseDTO;
+import com.eventostec.api.service.EventService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(EventController.class)
+class EventControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private EventService eventService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void test_createEventSuccess() throws Exception {
+        EventRequestDTO requestDTO = new EventRequestDTO("Evento Teste", "Descrição do evento", new Date().getTime(), "Cidade Teste", "UF", true, "https://evento.com", null);
+        Event responseEvent = new Event();
+
+        when(eventService.createEvent(requestDTO)).thenReturn(responseEvent);
+
+        mockMvc.perform(multipart("/api/event")
+                        .file("image", new byte[0])
+                        .param("title", requestDTO.title())
+                        .param("description", requestDTO.description())
+                        .param("date", String.valueOf(requestDTO.date()))
+                        .param("city", requestDTO.city())
+                        .param("state", requestDTO.state())
+                        .param("remote", String.valueOf(requestDTO.remote()))
+                        .param("eventUrl", requestDTO.eventUrl())
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void test_getEventDetails() throws Exception {
+        UUID eventId = UUID.randomUUID();
+        List<EventDetailsDTO.CouponDTO> coupons = List.of(
+                new EventDetailsDTO.CouponDTO("CODE123", 10, new Date()),
+                new EventDetailsDTO.CouponDTO("CODE456", 20, new Date())
+        );
+        EventDetailsDTO eventDetailsDTO = new EventDetailsDTO(
+                UUID.fromString("b4919825-dd11-4f6c-b77d-faffb48c1801"),
+                "Teste de evento",
+                "A maior conferencia do mundo",
+                new Date(),
+                "Brasilia",
+                "DF",
+                "",
+                "https://www.teste.com",
+                coupons
+        );
+
+        when(eventService.getEventDetails(eventId)).thenReturn(eventDetailsDTO);
+
+        mockMvc.perform(get("/api/event/{eventId}", eventId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").exists());
+    }
+
+    @Test
+    void test_getEvents() throws Exception {
+        List<EventResponseDTO> responseList = getEventResponseDTO();
+
+        when(eventService.getUpcomingEvents(0, 10)).thenReturn(responseList);
+
+        mockMvc.perform(get("/api/event")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0]").exists());
+    }
+
+    @Test
+    void test_deleteEvent() throws Exception {
+        UUID eventId = UUID.randomUUID();
+        String adminKey = "testAdminKey";
+
+        doNothing().when(eventService).deleteEvent(eventId, adminKey);
+
+        mockMvc.perform(delete("/api/event/{eventId}", eventId)
+                        .content(adminKey)
+                        .contentType(MediaType.TEXT_PLAIN))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void test_getFilteredEvents() throws Exception {
+        List<EventResponseDTO> responseList = getEventResponseDTO();
+        String startDate = "2024-10-24";
+        String endDate = "2024-10-25";
+
+        when(eventService.getFilteredEvents(0, 10, "Brasilia", "DF",
+                new SimpleDateFormat("yyyy-MM-dd").parse(startDate),
+                new SimpleDateFormat("yyyy-MM-dd").parse(endDate))).thenReturn(responseList);
+
+        mockMvc.perform(get("/api/event/filter")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .param("city", "Brasilia")
+                        .param("uf", "DF")
+                        .param("startDate", startDate)
+                        .param("endDate", endDate))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray());
+    }
+
+    @Test
+    void test_getSearchEvents() throws Exception {
+        List<EventResponseDTO> responseList = getEventResponseDTO();
+
+        when(eventService.searchEvents("evento")).thenReturn(responseList);
+
+        mockMvc.perform(get("/api/event/search")
+                        .param("title", "evento"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0]").exists());
+    }
+
+    private static List<EventResponseDTO> getEventResponseDTO() {
+        return List.of(new EventResponseDTO(
+                UUID.fromString("b4919825-dd11-4f6c-b77d-faffb48c1801"),
+                "Teste de evento",
+                "A maior conferencia do mundo",
+                new Date(),
+                "Brasilia",
+                "DF",
+                false,
+                "https://www.teste.com",
+                ""
+        ));
+    }
+}

--- a/src/test/java/com/eventostec/api/service/AddressServiceTest.java
+++ b/src/test/java/com/eventostec/api/service/AddressServiceTest.java
@@ -1,0 +1,80 @@
+package com.eventostec.api.service;
+
+import com.eventostec.api.domain.address.Address;
+import com.eventostec.api.domain.event.Event;
+import com.eventostec.api.domain.event.EventRequestDTO;
+import com.eventostec.api.repositories.AddressRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AddressServiceTest {
+
+    @Mock
+    private AddressRepository addressRepository;
+
+    @InjectMocks
+    private AddressService addressService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void test_shouldSaveAddress() {
+        Event event = new Event();
+        event.setId(UUID.randomUUID());
+        EventRequestDTO data = new EventRequestDTO("Teste Evento", "Descricao Evento", System.currentTimeMillis(), "Cidade Teste", "UF", true, "https://evento.com", null);
+        Address address = new Address();
+        address.setCity(data.city());
+        address.setUf(data.state());
+        address.setEvent(event);
+
+        when(addressRepository.save(any(Address.class))).thenReturn(address);
+
+        Address savedAddress = addressService.createAddress(data, event);
+
+        assertNotNull(savedAddress);
+        assertEquals(data.city(), savedAddress.getCity());
+        assertEquals(data.state(), savedAddress.getUf());
+        verify(addressRepository, times(1)).save(any(Address.class));
+    }
+
+    @Test
+    void test_shouldReturnAddress() {
+        UUID eventId = UUID.randomUUID();
+        Address address = new Address();
+        address.setCity("Cidade Teste");
+        address.setUf("UF");
+
+        when(addressRepository.findByEventId(eventId)).thenReturn(Optional.of(address));
+
+        Optional<Address> result = addressService.findByEventId(eventId);
+
+        assertTrue(result.isPresent());
+        assertEquals("Cidade Teste", result.get().getCity());
+        assertEquals("UF", result.get().getUf());
+        verify(addressRepository, times(1)).findByEventId(eventId);
+    }
+
+    @Test
+    void test_shouldReturnEmptyWhenAddressNotFound() {
+        UUID eventId = UUID.randomUUID();
+
+        when(addressRepository.findByEventId(eventId)).thenReturn(Optional.empty());
+
+        Optional<Address> result = addressService.findByEventId(eventId);
+
+        assertFalse(result.isPresent());
+        verify(addressRepository, times(1)).findByEventId(eventId);
+    }
+}

--- a/src/test/java/com/eventostec/api/service/CouponServiceTest.java
+++ b/src/test/java/com/eventostec/api/service/CouponServiceTest.java
@@ -1,0 +1,108 @@
+package com.eventostec.api.service;
+
+import com.eventostec.api.domain.coupon.Coupon;
+import com.eventostec.api.domain.coupon.CouponRequestDTO;
+import com.eventostec.api.domain.event.Event;
+import com.eventostec.api.repositories.CouponRepository;
+import com.eventostec.api.repositories.EventRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class CouponServiceTest {
+
+    @Mock
+    private CouponRepository couponRepository;
+
+    @Mock
+    private EventRepository eventRepository;
+
+    @InjectMocks
+    private CouponService couponService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void test_shouldSaveCoupon() {
+        UUID eventId = UUID.randomUUID();
+        Event event = new Event();
+        event.setId(eventId);
+        CouponRequestDTO couponData = new CouponRequestDTO("TESTCODE", 20, new Date().getTime());
+        Coupon coupon = new Coupon();
+        coupon.setCode(couponData.code());
+        coupon.setDiscount(couponData.discount());
+        coupon.setValid(new Date(couponData.valid()));
+        coupon.setEvent(event);
+
+        when(eventRepository.findById(eventId)).thenReturn(Optional.of(event));
+        when(couponRepository.save(any(Coupon.class))).thenReturn(coupon);
+
+        Coupon savedCoupon = couponService.addCouponToEvent(eventId, couponData);
+
+        assertNotNull(savedCoupon);
+        assertEquals("TESTCODE", savedCoupon.getCode());
+        verify(eventRepository, times(1)).findById(eventId);
+        verify(couponRepository, times(1)).save(any(Coupon.class));
+    }
+
+    @Test
+    void test_shouldThrowExceptionWhenEventNotFound() {
+        UUID eventId = UUID.randomUUID();
+        CouponRequestDTO couponData = new CouponRequestDTO("TESTCODE", 20, new Date().getTime());
+
+        when(eventRepository.findById(eventId)).thenReturn(Optional.empty());
+
+        assertThrows(IllegalArgumentException.class, () -> couponService.addCouponToEvent(eventId, couponData));
+        verify(eventRepository, times(1)).findById(eventId);
+        verify(couponRepository, never()).save(any(Coupon.class));
+    }
+
+    @Test
+    void test_shouldReturnListOfCoupons() {
+        UUID eventId = UUID.randomUUID();
+        Date currentDate = new Date();
+
+        Event event = new Event();
+        event.setId(eventId);
+        event.setTitle("Teste de evento");
+        event.setDescription("Descrição do evento");
+        event.setDate(new Date());
+        event.setEventUrl("https://evento.com");
+
+        List<Coupon> coupons = List.of(new Coupon(eventId, "CP123", 20, currentDate, event));
+
+        when(couponRepository.findByEventIdAndValidAfter(eventId, currentDate)).thenReturn(coupons);
+
+        List<Coupon> result = couponService.consultCoupons(eventId, currentDate);
+
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertEquals(1, result.size());
+        assertEquals("CP123", result.get(0).getCode());
+        verify(couponRepository, times(1)).findByEventIdAndValidAfter(eventId, currentDate);
+    }
+
+    @Test
+    void test_shouldReturnEmptyListWhenNoCouponsAvailable() {
+        UUID eventId = UUID.randomUUID();
+        Date currentDate = new Date();
+
+        when(couponRepository.findByEventIdAndValidAfter(eventId, currentDate)).thenReturn(Collections.emptyList());
+
+        List<Coupon> result = couponService.consultCoupons(eventId, currentDate);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+        verify(couponRepository, times(1)).findByEventIdAndValidAfter(eventId, currentDate);
+    }
+}

--- a/src/test/java/com/eventostec/api/service/EventServiceTest.java
+++ b/src/test/java/com/eventostec/api/service/EventServiceTest.java
@@ -1,0 +1,162 @@
+package com.eventostec.api.service;
+
+import com.eventostec.api.domain.event.*;
+import com.eventostec.api.repositories.EventRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Utilities;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+
+import java.net.URI;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class EventServiceTest {
+
+    @Mock
+    private S3Client s3Client;
+
+    @Mock
+    private S3Utilities s3Utilities;
+
+    @Mock
+    private AddressService addressService;
+
+    @Mock
+    private CouponService couponService;
+
+    @Mock
+    private EventRepository repository;
+
+    @InjectMocks
+    private EventService eventService;
+
+    private final String adminKey = "test-admin-key";
+    private final String bucketName = "test-bucket";
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        eventService = new EventService(s3Client, addressService, couponService, repository);
+        // Configurando valores diretamente nos atributos usando ReflectionTestUtils
+        ReflectionTestUtils.setField(eventService, "adminKey", adminKey);
+        ReflectionTestUtils.setField(eventService, "bucketName", bucketName);
+        // Mockando S3Utilities
+        when(s3Client.utilities()).thenReturn(s3Utilities);
+    }
+
+    @Test
+    void test_shouldSaveEvent() {
+        EventRequestDTO requestDTO = new EventRequestDTO("Evento Teste", "Descrição do evento", new Date().getTime(), "Cidade Teste", "UF", true, "https://evento.com", null);
+        Event event = new Event();
+
+        when(repository.save(any(Event.class))).thenReturn(event);
+
+        Event savedEvent = eventService.createEvent(requestDTO);
+
+        assertNotNull(savedEvent);
+        verify(repository, times(1)).save(any(Event.class));
+    }
+
+    @Test
+    void test_shouldReturnListOfEvents() {
+        Pageable pageable = PageRequest.of(0, 10);
+        List<EventAddressProjection> events = List.of(mock(EventAddressProjection.class));
+        Page<EventAddressProjection> eventsPage = new PageImpl<>(events);
+
+        when(repository.findUpcomingEvents(any(Date.class), eq(pageable))).thenReturn(eventsPage);
+
+        List<EventResponseDTO> result = eventService.getUpcomingEvents(0, 10);
+
+        assertFalse(result.isEmpty());
+        verify(repository, times(1)).findUpcomingEvents(any(Date.class), eq(pageable));
+    }
+
+    @Test
+    void test_shouldReturnEventDetails() {
+        UUID eventId = UUID.randomUUID();
+        Event event = new Event();
+        event.setId(eventId);
+        event.setTitle("Teste de evento");
+        event.setDescription("Descrição do evento");
+        event.setDate(new Date());
+        event.setEventUrl("https://evento.com");
+
+        when(repository.findById(eventId)).thenReturn(Optional.of(event));
+        when(addressService.findByEventId(eventId)).thenReturn(Optional.empty());
+        when(couponService.consultCoupons(eventId, new Date())).thenReturn(Collections.emptyList());
+
+        EventDetailsDTO result = eventService.getEventDetails(eventId);
+
+        assertNotNull(result);
+        assertEquals(eventId, result.id());
+        verify(repository, times(1)).findById(eventId);
+    }
+
+    @Test
+    void test_shouldDeleteEvent() {
+        UUID eventId = UUID.randomUUID();
+        Event event = new Event();
+        event.setId(eventId);
+
+        when(repository.findById(eventId)).thenReturn(Optional.of(event));
+
+        // Use a mesma chave de administrador configurada
+        eventService.deleteEvent(eventId, adminKey);
+
+        verify(repository, times(1)).delete(event);
+    }
+
+    @Test
+    void test_shouldReturnMatchingEvents() {
+        String title = "Evento Teste";
+        List<EventAddressProjection> events = List.of(mock(EventAddressProjection.class));
+
+        when(repository.findEventsByTitle(title)).thenReturn(events);
+
+        List<EventResponseDTO> result = eventService.searchEvents(title);
+
+        assertFalse(result.isEmpty());
+        verify(repository, times(1)).findEventsByTitle(title);
+    }
+
+    @Test
+    void test_shouldReturnFilteredEvents() {
+        Pageable pageable = PageRequest.of(0, 10);
+        List<EventAddressProjection> events = List.of(mock(EventAddressProjection.class));
+        Page<EventAddressProjection> eventsPage = new PageImpl<>(events);
+
+        when(repository.findFilteredEvents(anyString(), anyString(), any(Date.class), any(Date.class), eq(pageable))).thenReturn(eventsPage);
+
+        List<EventResponseDTO> result = eventService.getFilteredEvents(0, 10, "Cidade Teste", "UF", new Date(), new Date());
+
+        assertFalse(result.isEmpty());
+        verify(repository, times(1)).findFilteredEvents(anyString(), anyString(), any(Date.class), any(Date.class), eq(pageable));
+    }
+
+    @Test
+    void test_shouldReturnUrlOnUploadImage() throws Exception {
+        MultipartFile multipartFile = mock(MultipartFile.class);
+        when(multipartFile.getBytes()).thenReturn(new byte[0]);
+        when(multipartFile.getOriginalFilename()).thenReturn("imagem.jpg");
+        when(s3Utilities.getUrl(any(GetUrlRequest.class))).thenReturn(URI.create("https://s3.amazonaws.com/teste/imagem.jpg").toURL());
+
+        ReflectionTestUtils.setField(eventService, "bucketName", bucketName);
+        String result = ReflectionTestUtils.invokeMethod(eventService, "uploadImg", multipartFile);
+
+        assertNotNull(result);
+        assertTrue(result.contains("https://s3.amazonaws.com"));
+    }
+}


### PR DESCRIPTION
## O que foi alterado?

- [ ] Nova funcionalidade
- [ ] Correção de bug
- [ ] Melhorias na documentação
- [X] Outro (especificar): 

Tratamento de exceções e validação de campos

## Issue relacionada

Este Pull Request resolve uma issue?

- [x] Sim
- [ ] Não

Se sim, por favor, insira o link da issue:

[Link para issue](https://github.com/Fernanda-Kipper/eventostec-backend/issues/3)

# Checklist

- [x] Eu revisei meu código
- [x] Eu fiz um teste local das minhas alterações

# Comentários adicionais

**OBS.:** Foram muitas alterações pequenas mas as maiores e principais foram o tratamento de exceções e as validações.

- Spring Boot atualizado para versão 3.3.4 (sugestão do sonar sobre vulnerabilidade de dependência do Spring);
- Criadas classes para tratamento de exceção e com resposta padronizada, baseado na RFC7808. Inclusive, um outro pull request(https://github.com/Fernanda-Kipper/eventostec-frontend/pull/76) que fiz do eventostec-frontend já foi pensando nessa estrutura;
- Feito o máximo posśivel da cobertura de código (**61%**) da aplicação no tempo disponível ;
- Adicionada dependencia para validação de campos nos endpoint;
- Adicionada configuração para o jacoco;
- Alterado o endpoint 'createEvent' para receber um DTO ao invés dos parametros individuais (atende issue: https://github.com/Fernanda-Kipper/eventostec-backend/issues/3);
- Feita validação com SonarLint e realizadas varias melhorias baseadas nas sugestões dele: alterado o ponto de injeção de dependencia de campo(https://www.baeldung.com/java-spring-field-injection-cons), tratamento de possiveis pontos de NullPointerException, troca de System.out.println por log, remoção de imports não utilizados, entre outros.

## Data inválida
![image](https://github.com/user-attachments/assets/e76ac1c0-18f2-4025-b031-46c0541ace8e)

## URL inválida
![evidencia_url_invalida](https://github.com/user-attachments/assets/a1c7b329-7ce4-4229-aca2-1f5da8805bc9)

## Cobertura de testes
![image](https://github.com/user-attachments/assets/c86a5b52-a443-4884-a466-6d65a32680f6)
